### PR TITLE
fixed namespace error in cstring include

### DIFF
--- a/lib/primitives/stdlib/sys/io/output/fmt_implementation.hpp
+++ b/lib/primitives/stdlib/sys/io/output/fmt_implementation.hpp
@@ -204,8 +204,6 @@ data primitive_fmt_bwhite8(data_vector&& args){return heist_fmt::generate_ANSI_f
 * PRIVATE INTERFACES: ASCII/WHITESPACE ART PRINTING HELPER FUNCTIONS
 ******************************************************************************/
 
-#include <cstring>
-
 namespace heist_fmt {
   // max strlen, ASCII/Whitespace art alphabet length, # rows per alpha art letter, '\b' alpha art idx
   static constexpr const std::size_t ALPHA_ART_ALPHABET_LENGTH = 74;

--- a/lib/primitives/stdlib/sys/io/output/output.hpp
+++ b/lib/primitives/stdlib/sys/io/output/output.hpp
@@ -5,6 +5,7 @@
 #define HEIST_SCHEME_CORE_STDLIB_OUTPUT_HPP_
 
 #include "implementation.hpp"
+#include <cstring>
 
 namespace heist {
 


### PR DESCRIPTION
Had to move `#include <cstring>` out of the Heist namespace (and thus out of `fmt_implementation.hpp` into `output.hpp`) to get it to compile. Compiled just fine after that.
